### PR TITLE
Refactor handlers for injectable utilities

### DIFF
--- a/EnterpriseCQRS.Services/CommandHandlers/ProductCommandHandler/ProductCommandHandler.cs
+++ b/EnterpriseCQRS.Services/CommandHandlers/ProductCommandHandler/ProductCommandHandler.cs
@@ -20,11 +20,13 @@ namespace EnterpriseCQRS.Services.CommandHandlers.ProductCommandHandler
         {
             private readonly CommittedCapacityContext _context;
             private readonly ILogger logger;
+            private readonly IUtilities<Transaction> _service;
 
-            public GetTransactionCommandHandler(CommittedCapacityContext context, ILogger<GetTransactionCommandHandler> logger)
+            public GetTransactionCommandHandler(CommittedCapacityContext context, ILogger<GetTransactionCommandHandler> logger, IUtilities<Transaction> service)
             {
                 _context = context;
                 this.logger = logger;
+                _service = service;
             }
 
             public async Task<GenericResponse<IList<Transaction>>> Handle(GetTransactionCommand request, CancellationToken cancellationToken)
@@ -32,14 +34,13 @@ namespace EnterpriseCQRS.Services.CommandHandlers.ProductCommandHandler
                 logger.LogInformation("comienza a ejecutar el handler");
                 var url = new Uri("http://quiet-stone-2094.herokuapp.com/transactions.json");
                 var response = new GenericResponse<IList<Transaction>>();
-                var transactions = new Utilities<Transaction>();
 
                 logger.LogWarning("se realiza proceso de eliminado de info de la tabla");
                 _context.Database.ExecuteSqlRaw("DELETE FROM [Transaction]");
                 logger.LogWarning("Termino el proceso de eliminado de info de la tabla");
 
                 logger.LogWarning("se realiza proceso de consumir servicio externo");
-                var responses = await transactions.ExternalServiceUtility(url);
+                var responses = await _service.ExternalServiceUtility(url);
                 logger.LogWarning("Termino el proceso de eliminado de info de la tabla");
 
                 if (responses.Result is null)
@@ -63,11 +64,13 @@ namespace EnterpriseCQRS.Services.CommandHandlers.ProductCommandHandler
         {
             private readonly CommittedCapacityContext _context;
             private readonly ILogger<GetRateCommandHandler> logger;
+            private readonly IUtilities<Rates> _service;
 
-            public GetRateCommandHandler(CommittedCapacityContext context, ILogger<GetRateCommandHandler> logger)
+            public GetRateCommandHandler(CommittedCapacityContext context, ILogger<GetRateCommandHandler> logger, IUtilities<Rates> service)
             {
                 _context = context;
                 this.logger = logger;
+                _service = service;
             }
 
             public async Task<GenericResponse<IList<Rates>>> Handle(GetRateCommand request, CancellationToken cancellationToken)
@@ -75,14 +78,13 @@ namespace EnterpriseCQRS.Services.CommandHandlers.ProductCommandHandler
                 logger.LogInformation("comienza a ejecutar el handler");
                 var url = new Uri("http://quiet-stone-2094.herokuapp.com/rates.json");
                 var response = new GenericResponse<IList<Rates>>();
-                var rates = new Utilities<Rates>();
 
                 logger.LogInformation("se realiza proceso de eliminado de info de la tabla");
                 _context.Database.ExecuteSqlRaw("DELETE FROM [Rates]");
                 logger.LogInformation("Termino el proceso de eliminado de info de la tabla");
 
                 logger.LogInformation("se realiza proceso de consumir servicio externo");
-                var responses = await rates.ExternalServiceUtility(url);
+                var responses = await _service.ExternalServiceUtility(url);
                 logger.LogInformation("Termino el proceso de eliminado de info de la tabla");
 
                 if (responses.Result is null)

--- a/EnterpriseCQRS.Services/CommandHandlers/Utilities/IUtilities.cs
+++ b/EnterpriseCQRS.Services/CommandHandlers/Utilities/IUtilities.cs
@@ -1,0 +1,12 @@
+namespace EnterpriseCQRS.Services.CommandHandlers.Utilities
+{
+    using EnterpriseCQRS.Domain.Responses;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public interface IUtilities<T> where T : class
+    {
+        Task<GenericResponse<IList<T>>> ExternalServiceUtility(Uri url);
+    }
+}

--- a/EnterpriseCQRS.Services/CommandHandlers/Utilities/Utilities.cs
+++ b/EnterpriseCQRS.Services/CommandHandlers/Utilities/Utilities.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace EnterpriseCQRS.Services.CommandHandlers.Utilities
 {
-    public class Utilities<T> where T : class
+    public class Utilities<T> : IUtilities<T> where T : class
     {
         public async Task<GenericResponse<IList<T>>> ExternalServiceUtility(Uri url)
         {

--- a/EnterpriseCQRS.XUnitTests/ProductCommandHandlerTests.cs
+++ b/EnterpriseCQRS.XUnitTests/ProductCommandHandlerTests.cs
@@ -1,11 +1,15 @@
 using EnterpriseCQRS.Data;
+using EnterpriseCQRS.Data.Model;
 using EnterpriseCQRS.Domain.Commands.ProductCommand;
 using Microsoft.Extensions.Logging;
 using Moq;
+using EnterpriseCQRS.Domain.Responses;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Xunit;
 using static EnterpriseCQRS.Services.CommandHandlers.ProductCommandHandler.ProductCommandHandler;
+using EnterpriseCQRS.Services.CommandHandlers.Utilities;
 
 namespace EnterpriseCQRS.XUnitTests
 {
@@ -14,12 +18,16 @@ namespace EnterpriseCQRS.XUnitTests
         private readonly CommittedCapacityContext _context;
         private readonly Mock<ILogger<GetTransactionCommandHandler>> _mockLogger;
         private readonly Mock<ILogger<GetRateCommandHandler>> _mockRateLogger;
+        private readonly Mock<IUtilities<Transaction>> _mockService;
+        private readonly Mock<IUtilities<Rates>> _mockRateService;
 
         public ProductCommandHandlerTests()
         {
             _context = GetDbContext();
             _mockLogger = new Mock<ILogger<GetTransactionCommandHandler>>();
             _mockRateLogger = new Mock<ILogger<GetRateCommandHandler>>();
+            _mockService = new Mock<IUtilities<Transaction>>();
+            _mockRateService = new Mock<IUtilities<Rates>>();
         }
 
         [Fact]
@@ -27,13 +35,24 @@ namespace EnterpriseCQRS.XUnitTests
         {
             var request = new GetTransactionCommand();
 
-            var handle = new GetTransactionCommandHandler(_context, _mockLogger.Object);
+            var transactionsList = new List<Transaction>
+            {
+                new Transaction { Sku = "T1", Amount = "10", Currency = "USD" },
+                new Transaction { Sku = "T2", Amount = "5", Currency = "EUR" }
+            };
+
+            _mockService
+                .Setup(x => x.ExternalServiceUtility(It.IsAny<Uri>()))
+                .ReturnsAsync(new GenericResponse<IList<Transaction>> { Result = transactionsList });
+
+            var handle = new GetTransactionCommandHandler(_context, _mockLogger.Object, _mockService.Object);
 
             var resultResponseMessage = "Guardado exitoso";
 
             var responses = await handle.Handle(request, new CancellationToken());
 
             Assert.Contains(resultResponseMessage, responses.Message);
+            Assert.Equal(2, await _context.Transaction.CountAsync());
         }
 
         [Fact]
@@ -41,13 +60,24 @@ namespace EnterpriseCQRS.XUnitTests
         {
             var request = new GetRateCommand();
 
-            var handle = new GetRateCommandHandler(_context, _mockRateLogger.Object);
+            var rateList = new List<Rates>
+            {
+                new Rates { From = "USD", To = "EUR", Rate = "0.5" },
+                new Rates { From = "EUR", To = "USD", Rate = "2" }
+            };
+
+            _mockRateService
+                .Setup(x => x.ExternalServiceUtility(It.IsAny<Uri>()))
+                .ReturnsAsync(new GenericResponse<IList<Rates>> { Result = rateList });
+
+            var handle = new GetRateCommandHandler(_context, _mockRateLogger.Object, _mockRateService.Object);
 
             var resultResponseMessage = "Guardado exitoso";
 
             var responses = await handle.Handle(request, new CancellationToken());
 
             Assert.Equal(resultResponseMessage, responses.Message);
+            Assert.Equal(2, await _context.Rates.CountAsync());
         }
     }
 }

--- a/EnterpriseCQRS.XUnitTests/ProductCommandHandlerTests.cs
+++ b/EnterpriseCQRS.XUnitTests/ProductCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using EnterpriseCQRS.Data;
 using EnterpriseCQRS.Data.Model;
 using EnterpriseCQRS.Domain.Commands.ProductCommand;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using EnterpriseCQRS.Domain.Responses;
 using System.Threading;


### PR DESCRIPTION
## Summary
- allow HTTP calls to be injected via new `IUtilities<T>` interface
- update product handlers to accept `IUtilities` dependencies
- mock HTTP calls in unit tests and verify database entries

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bb1590a08328a6181678abfb143c