### PR TITLE
Fix connection string path

### DIFF
--- a/EnterpriseCQRS.Api/appsettings.json
+++ b/EnterpriseCQRS.Api/appsettings.json
@@ -1,7 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Data Source=C:\\Users\\User\\Desktop\\git-ditech\\ditech-test\\EnterpriseCQRS.Data\\Database.db"
-    //"DefaultConnection": "Data Source=DESKTOP-1AJC91H\\SQLEXPRESS;Database=Cqrs;Integrated Security=True;"
+    "DefaultConnection": "Data Source=../EnterpriseCQRS.Data/Database.db"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- fix connection string path so it works cross-platform

## Testing
- `dotnet test EnterpriseCQRS.Api.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b788fee88328ac3ae301b35149f5